### PR TITLE
feat(ai): streaming chat with SSE, auth gate, and Markdown rendering

### DIFF
--- a/src/app/(public)/auth/signup/page.tsx
+++ b/src/app/(public)/auth/signup/page.tsx
@@ -180,7 +180,7 @@ export default function SignUp() {
 
   return (
     <>
-      <TitleSection title="Criar uma conta" />
+      <TitleSection title="Criar conta" />
       <Flex alignItems="center" flexDirection="column" height="100%" justifyContent="start" width="100%">
         <Flex
           as="form"

--- a/src/app/api/ai/chat/route.ts
+++ b/src/app/api/ai/chat/route.ts
@@ -33,10 +33,7 @@ export async function POST(request: NextRequest): Promise<Response> {
         Connection: "keep-alive"
       }
     });
-  } catch (err) {
-    if (process.env.NODE_ENV !== "production") {
-      console.error("[/api/ai/chat]", err);
-    }
+  } catch {
     return new Response(JSON.stringify({ error: "Deu ruim truta! Tente novamente." }), {
       status: 500,
       headers: { "Content-Type": "application/json" }

--- a/src/app/api/ai/chat/route.ts
+++ b/src/app/api/ai/chat/route.ts
@@ -1,10 +1,20 @@
 import { NextRequest } from "next/server";
+import { parseCookies } from "nookies";
 
 import { streamChatResponse } from "@/server/lib/openrouter";
-// To use Gemini instead, swap the import above to:
-// import { streamChatResponse } from "@/server/lib/gemini";
 
 export async function POST(request: NextRequest): Promise<Response> {
+  // Hard auth gate — never call the AI provider for unauthenticated requests
+  const cookies = parseCookies({ req: request } as never);
+  const token = cookies["auth.token"] ?? request.cookies.get("auth.token")?.value;
+
+  if (!token) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" }
+    });
+  }
+
   try {
     const body = await request.json();
     const { message } = body as { message: unknown };

--- a/src/app/api/ai/chat/route.ts
+++ b/src/app/api/ai/chat/route.ts
@@ -1,12 +1,10 @@
 import { NextRequest } from "next/server";
-import { parseCookies } from "nookies";
 
 import { streamChatResponse } from "@/server/lib/openrouter";
 
 export async function POST(request: NextRequest): Promise<Response> {
   // Hard auth gate — never call the AI provider for unauthenticated requests
-  const cookies = parseCookies({ req: request } as never);
-  const token = cookies["auth.token"] ?? request.cookies.get("auth.token")?.value;
+  const token = request.cookies.get("auth.token")?.value;
 
   if (!token) {
     return new Response(JSON.stringify({ error: "Unauthorized" }), {
@@ -35,7 +33,10 @@ export async function POST(request: NextRequest): Promise<Response> {
         Connection: "keep-alive"
       }
     });
-  } catch {
+  } catch (err) {
+    if (process.env.NODE_ENV !== "production") {
+      console.error("[/api/ai/chat]", err);
+    }
     return new Response(JSON.stringify({ error: "Deu ruim truta! Tente novamente." }), {
       status: 500,
       headers: { "Content-Type": "application/json" }

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -93,7 +93,7 @@ export function Header() {
               </Button>
 
               <Button variant="ghost" color={textSecondaryButton} size={["sm", "sm"]} onClick={handleSignupClick}>
-                Criar uma conta
+                Criar conta
               </Button>
             </Flex>
           ) : (

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -3,7 +3,7 @@
 import { useContext } from "react";
 import { RiMenuLine } from "react-icons/ri";
 // import Link from 'next/link';
-import { useRouter, useSearchParams } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
 import { Button, Flex, Icon, IconButton, Link, useBreakpointValue, useColorModeValue } from "@chakra-ui/react";
 
@@ -23,6 +23,7 @@ export function Header() {
   const { onOpen } = useSidebarDrawer();
   const { isAuthenticated } = useContext(AuthContext);
   const router = useRouter();
+  const pathname = usePathname();
   const searchParams = useSearchParams();
   const textSecondaryButton = useColorModeValue("gray.800", "green.400");
 
@@ -34,11 +35,11 @@ export function Header() {
   const isLoginModalOpen = (searchParams?.get("modal") || "") === "login";
 
   const handleClose = () => {
-    router.push("/");
+    router.push(pathname);
   };
 
   const handleLoginClick = () => {
-    router.push("/?modal=login");
+    router.push(`${pathname}?modal=login`);
   };
 
   const handleSignupClick = () => {

--- a/src/features/ai/Chat/index.tsx
+++ b/src/features/ai/Chat/index.tsx
@@ -3,9 +3,9 @@
 import { useEffect, useRef, useState } from "react";
 import { RiRobot2Line } from "react-icons/ri";
 import { TbSkateboard } from "react-icons/tb";
+import NextLink from "next/link";
 
 import { Box, Button, Center, HStack, Spinner, Text, VStack } from "@chakra-ui/react";
-import NextLink from "next/link";
 
 import { useAIChat } from "@/hooks/useAIChat";
 import { useColors } from "@/hooks/useColors";
@@ -175,7 +175,7 @@ export function Chat() {
               _hover={{ bg: "green.500" }}
               size="sm"
             >
-              Entrar
+              Login
             </Button>
             <Button
               as={NextLink}

--- a/src/features/ai/Chat/index.tsx
+++ b/src/features/ai/Chat/index.tsx
@@ -2,9 +2,9 @@
 
 import { useEffect, useRef, useState } from "react";
 import { RiRobot2Line } from "react-icons/ri";
-import { TbSkateboard } from "react-icons/tb";
 
 import { Box, Button, Center, HStack, Spinner, Text, VStack } from "@chakra-ui/react";
+import NextLink from "next/link";
 
 import { useAIChat } from "@/hooks/useAIChat";
 import { useColors } from "@/hooks/useColors";
@@ -19,19 +19,17 @@ const INITIAL_SUGGESTIONS = [
 ];
 
 export function Chat() {
-  const { messages, isPending, submitMessage } = useAIChat();
+  const { messages, isPending, isAuthenticated, submitMessage } = useAIChat();
   const [inputValue, setInputValue] = useState("");
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const isConversationStarted = messages.length > 0;
-  const { bgColor, cardBg, border, textPrimary, textMuted, chatIASuggestionBg } = useColors();
+  const { bgColor, cardBg, border, textPrimary, textMuted } = useColors();
 
-  // Auto-scroll to bottom when new messages arrive
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages]);
 
-  // Focus input after sending
   useEffect(() => {
     if (!isPending) {
       inputRef.current?.focus();
@@ -57,8 +55,8 @@ export function Chat() {
   };
 
   return (
-    <VStack h="800px" w="100%" spacing={0} justify="space-between">
-      {/* Hero Section - always visible */}
+    <VStack h="800px" w="100%" spacing={0} justify="space-between" p={4}>
+      {/* Hero Section */}
       <VStack spacing={4} textAlign="center" py={4}>
         <Box w={16} h={16} borderRadius="full" bg={bgColor} display="flex" alignItems="center" justifyContent="center">
           <RiRobot2Line size={32} color="#48D597" />
@@ -68,16 +66,26 @@ export function Chat() {
             Truta IA
           </Text>
           <Text fontSize="md" color={textMuted}>
-            E aí truta! Sou o assistente do SkateHub. Pronto para dropar no conhecimento? Como posso te ajudar hoje?
+            E aí truta! Sou o assistente do SkateHub.
+            <br />
+            Pronto para dropar no conhecimento? Como posso te ajudar hoje?
           </Text>
         </VStack>
       </VStack>
 
       {/* Main content area */}
-      <Box flex={1} w="100%" overflowY="auto" borderRadius="md" mb={4} maxW="800px" mx="auto">
+      <Box
+        flex={1}
+        w="100%"
+        overflowY="auto"
+        borderRadius="md"
+        mb={4}
+        maxW="800px"
+        mx="auto"
+        className="scroll-container"
+      >
         {!isConversationStarted ? (
-          /* Suggestions (before conversation) */
-          <Center h="100%" flexDirection="column">
+          <Center h="100%" flexDirection="column" gap={8}>
             <VStack spacing={3} align="stretch" w="100%" maxW="500px">
               {INITIAL_SUGGESTIONS.map((suggestion, idx) => (
                 <Button
@@ -90,18 +98,16 @@ export function Chat() {
                   py={3}
                   px={4}
                   whiteSpace="normal"
-                  bg={chatIASuggestionBg}
-                  _hover={{ borderColor: "green.400", bg: cardBg }}
-                  gap={4}
+                  borderColor={border}
+                  isDisabled={!isAuthenticated}
+                  _hover={isAuthenticated ? { borderColor: "green.400", bg: cardBg } : {}}
                 >
-                  <TbSkateboard size={18} />
                   {suggestion}
                 </Button>
               ))}
             </VStack>
           </Center>
         ) : (
-          /* Chat area (after first message) */
           <VStack align="stretch" spacing={4} mt={5}>
             {messages
               .filter(msg => msg.role === "user" || msg.content !== "")
@@ -121,33 +127,65 @@ export function Chat() {
         )}
       </Box>
 
-      {/* Input area */}
-      <HStack w="100%" maxW="800px" mx="auto" spacing={2}>
-        <Input
-          ref={inputRef}
-          value={inputValue}
-          onChange={e => setInputValue(e.target.value)}
-          onKeyDown={handleKeyDown}
-          placeholder="Manda as ideias sobre o skate..."
-          isDisabled={isPending}
+      {/* Input area — auth gate */}
+      {isAuthenticated ? (
+        <HStack w="100%" maxW="800px" mx="auto" spacing={2}>
+          <Input
+            ref={inputRef}
+            value={inputValue}
+            onChange={e => setInputValue(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Manda as ideias sobre o skate..."
+            isDisabled={isPending}
+            borderColor={border}
+            _focus={{ borderColor: "green.400" }}
+          />
+          <Button
+            onClick={handleSubmit}
+            isLoading={isPending}
+            loadingText="Enviando"
+            disabled={!inputValue.trim() || isPending}
+            bg="green.400"
+            color="white"
+            _hover={{ bg: "green.500" }}
+            _disabled={{ opacity: 0.5, cursor: "not-allowed" }}
+          >
+            Enviar
+          </Button>
+        </HStack>
+      ) : (
+        <VStack
+          w="100%"
+          maxW="800px"
+          mx="auto"
+          spacing={3}
+          py={4}
+          px={4}
+          borderRadius="md"
+          borderWidth={1}
           borderColor={border}
-          _focus={{
-            borderColor: "green.400"
-          }}
-        />
-        <Button
-          onClick={handleSubmit}
-          isLoading={isPending}
-          loadingText="Enviando"
-          disabled={!inputValue.trim() || isPending}
-          bg="green.400"
-          color="white"
-          _hover={{ bg: "green.500" }}
-          _disabled={{ opacity: 0.5, cursor: "not-allowed" }}
         >
-          Enviar
-        </Button>
-      </HStack>
+          <Text fontSize="sm" color={textMuted} textAlign="center">
+            Para conversar com a Truta IA, entra na tua conta ou cria uma conta gratuitamente.
+          </Text>
+          <HStack spacing={3}>
+            <Button as={NextLink} href="/auth/signin" bg="green.400" color="white" _hover={{ bg: "green.500" }} size="sm">
+              Entrar
+            </Button>
+            <Button
+              as={NextLink}
+              href="/auth/register"
+              variant="outline"
+              borderColor="green.400"
+              color="green.400"
+              _hover={{ bg: cardBg }}
+              size="sm"
+            >
+              Criar conta
+            </Button>
+          </HStack>
+        </VStack>
+      )}
     </VStack>
   );
 }

--- a/src/features/ai/Chat/index.tsx
+++ b/src/features/ai/Chat/index.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import { RiRobot2Line } from "react-icons/ri";
+import { TbSkateboard } from "react-icons/tb";
 
 import { Box, Button, Center, HStack, Spinner, Text, VStack } from "@chakra-ui/react";
 import NextLink from "next/link";
@@ -24,12 +25,14 @@ export function Chat() {
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const isConversationStarted = messages.length > 0;
-  const { bgColor, cardBg, border, textPrimary, textMuted } = useColors();
+  const { bgColor, cardBg, border, textPrimary, textMuted, chatIASuggestionBg } = useColors();
 
+  // Auto-scroll to bottom when new messages arrive
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages]);
 
+  // Focus input after sending
   useEffect(() => {
     if (!isPending) {
       inputRef.current?.focus();
@@ -55,8 +58,8 @@ export function Chat() {
   };
 
   return (
-    <VStack h="800px" w="100%" spacing={0} justify="space-between" p={4}>
-      {/* Hero Section */}
+    <VStack h="800px" w="100%" spacing={0} justify="space-between">
+      {/* Hero Section - always visible */}
       <VStack spacing={4} textAlign="center" py={4}>
         <Box w={16} h={16} borderRadius="full" bg={bgColor} display="flex" alignItems="center" justifyContent="center">
           <RiRobot2Line size={32} color="#48D597" />
@@ -66,26 +69,16 @@ export function Chat() {
             Truta IA
           </Text>
           <Text fontSize="md" color={textMuted}>
-            E aí truta! Sou o assistente do SkateHub.
-            <br />
-            Pronto para dropar no conhecimento? Como posso te ajudar hoje?
+            E aí truta! Sou o assistente do SkateHub. Pronto para dropar no conhecimento? Como posso te ajudar hoje?
           </Text>
         </VStack>
       </VStack>
 
       {/* Main content area */}
-      <Box
-        flex={1}
-        w="100%"
-        overflowY="auto"
-        borderRadius="md"
-        mb={4}
-        maxW="800px"
-        mx="auto"
-        className="scroll-container"
-      >
+      <Box flex={1} w="100%" overflowY="auto" borderRadius="md" mb={4} maxW="800px" mx="auto">
         {!isConversationStarted ? (
-          <Center h="100%" flexDirection="column" gap={8}>
+          /* Suggestions (before conversation) */
+          <Center h="100%" flexDirection="column">
             <VStack spacing={3} align="stretch" w="100%" maxW="500px">
               {INITIAL_SUGGESTIONS.map((suggestion, idx) => (
                 <Button
@@ -98,16 +91,19 @@ export function Chat() {
                   py={3}
                   px={4}
                   whiteSpace="normal"
-                  borderColor={border}
+                  bg={chatIASuggestionBg}
                   isDisabled={!isAuthenticated}
                   _hover={isAuthenticated ? { borderColor: "green.400", bg: cardBg } : {}}
+                  gap={4}
                 >
+                  <TbSkateboard size={18} />
                   {suggestion}
                 </Button>
               ))}
             </VStack>
           </Center>
         ) : (
+          /* Chat area (after first message) */
           <VStack align="stretch" spacing={4} mt={5}>
             {messages
               .filter(msg => msg.role === "user" || msg.content !== "")
@@ -138,7 +134,9 @@ export function Chat() {
             placeholder="Manda as ideias sobre o skate..."
             isDisabled={isPending}
             borderColor={border}
-            _focus={{ borderColor: "green.400" }}
+            _focus={{
+              borderColor: "green.400"
+            }}
           />
           <Button
             onClick={handleSubmit}
@@ -169,7 +167,14 @@ export function Chat() {
             Para conversar com a Truta IA, entra na tua conta ou cria uma conta gratuitamente.
           </Text>
           <HStack spacing={3}>
-            <Button as={NextLink} href="/auth/signin" bg="green.400" color="white" _hover={{ bg: "green.500" }} size="sm">
+            <Button
+              as={NextLink}
+              href="/auth/signin"
+              bg="green.400"
+              color="white"
+              _hover={{ bg: "green.500" }}
+              size="sm"
+            >
               Entrar
             </Button>
             <Button

--- a/src/features/ai/Chat/index.tsx
+++ b/src/features/ai/Chat/index.tsx
@@ -164,7 +164,7 @@ export function Chat() {
           borderColor={border}
         >
           <Text fontSize="sm" color={textMuted} textAlign="center">
-            Para conversar com a Truta IA, entra na tua conta ou cria uma conta gratuitamente.
+            Para conversar com a Truta IA, faça seu login ou crie uma conta gratuitamente.
           </Text>
           <HStack spacing={3}>
             <Button

--- a/src/features/login/modal/login.tsx
+++ b/src/features/login/modal/login.tsx
@@ -251,7 +251,7 @@ export default function LoginModal() {
                 w="100%"
                 onClick={() => router.push("/auth/signup")}
               >
-                Criar uma conta
+                Criar conta
               </Button>
             </Flex>
           </Flex>

--- a/src/hooks/useAIChat.ts
+++ b/src/hooks/useAIChat.ts
@@ -1,13 +1,17 @@
 import { useState } from "react";
 
+import { useAuth } from "@/hooks/useAuth";
 import { streamClient } from "@/lib/streamClient";
 import type { Message } from "@/types/ai";
 
 export function useAIChat() {
+  const { isAuthenticated } = useAuth();
   const [messages, setMessages] = useState<Message[]>([]);
   const [isPending, setIsPending] = useState(false);
 
   const submitMessage = async (userMessage: string) => {
+    if (!isAuthenticated) return;
+
     const userId = `user-${Date.now()}`;
     setMessages(prev => [...prev, { id: userId, role: "user", content: userMessage }]);
     setIsPending(true);
@@ -61,5 +65,5 @@ export function useAIChat() {
     }
   };
 
-  return { messages, isPending, submitMessage };
+  return { messages, isPending, isAuthenticated, submitMessage };
 }

--- a/src/server/lib/openrouter.ts
+++ b/src/server/lib/openrouter.ts
@@ -10,7 +10,7 @@ const OPENROUTER_API_URL = "https://openrouter.ai/api/v1/chat/completions";
 // - "meta-llama/llama-3.3-70b-instruct:free"
 // - "deepseek/deepseek-r1:free"
 // - "google/gemma-3-27b-it:free"
-const MODEL = "meta-llama/llama-3.3-70b-instruct:free";
+const MODEL = "openrouter/free";
 
 export interface ChatOptions {
   message: string;

--- a/src/server/lib/openrouter.ts
+++ b/src/server/lib/openrouter.ts
@@ -10,7 +10,7 @@ const OPENROUTER_API_URL = "https://openrouter.ai/api/v1/chat/completions";
 // - "meta-llama/llama-3.3-70b-instruct:free"
 // - "deepseek/deepseek-r1:free"
 // - "google/gemma-3-27b-it:free"
-const MODEL = "openrouter/free";
+const MODEL = "meta-llama/llama-3.3-70b-instruct:free";
 
 export interface ChatOptions {
   message: string;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -34,6 +34,17 @@ export const theme = extendTheme({
         bg: props.colorMode === "light" ? "gray.50" : "gray.900",
         color: props.colorMode === "light" ? "gray.900" : "gray.50",
         height: "unset"
+      },
+      ".scroll-container": {
+        height: "500px",
+        overflow: "auto",
+        background: [
+          "linear-gradient(white 30%, rgba(255, 255, 255, 0)) center top",
+          "radial-gradient(farthest-side at 50% 0, rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0)) center top"
+        ].join(", "),
+        backgroundRepeat: "no-repeat",
+        backgroundSize: "100% 40px, 100% 14px",
+        backgroundAttachment: "local, scroll"
       }
     })
   }


### PR DESCRIPTION
## Summary

- Replaces the JSON-based AI chat route with a full SSE streaming pipeline (OpenRouter + Gemini)
- Adds a 3-layer auth gate: API route returns 401, hook short-circuits, UI shows sign-in prompt
- Renders assistant messages with `react-markdown` for proper formatting

## Changes

### New / Modified
- `src/app/api/ai/chat/route.ts` — SSE route with cookie auth gate and user-friendly error handling
- `src/server/lib/openrouter.ts` — `streamChatResponse` added
- `src/server/lib/gemini.ts` — `streamChatResponse` with SSE normalization to OpenRouter shape
- `src/lib/streamClient.ts` — new fetch wrapper with base URL + auth token (mirrors `apiClient`)
- `src/hooks/useAIChat.ts` — stream consumer; exposes `isAuthenticated` for UI gate
- `src/features/ai/Chat/index.tsx` — spinner hides on first token; auth gate UI
- `src/features/ai/Message/index.tsx` — `react-markdown` for assistant messages

### Minor
- `Criar conta` label consistency across Header, login modal, and signup page

## Notes

- **OpenRouter API key in `.env.local` is still invalid** — needs a new key from [openrouter.ai/keys](https://openrouter.ai/keys) before the feature can be tested end-to-end in production
- `getServerSideProps` export in `login.tsx` is a dead export (App Router ignores it) — tracked separately