### PR TITLE
chore: remove deprecated unstable_sentryWebpackPluginOptions

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -33,12 +33,6 @@ export default withSentryConfig(nextConfig, {
   // Suppress the Sentry CLI output during builds
   silent: !process.env.CI,
 
-  // Automatically tree-shake Sentry debug logging in production (Turbopack-compatible)
-  // disableLogger is deprecated; use webpack.treeshake instead for webpack builds
-  unstable_sentryWebpackPluginOptions: {
-    debug: false
-  },
-
   // Upload source maps to Sentry so stack traces are readable
   widenClientFileUpload: true
 });


### PR DESCRIPTION
## Summary
- Removes the deprecated `unstable_sentryWebpackPluginOptions` block from `next.config.ts`
- The `debug: false` option it contained is the default and has no functional effect
- Eliminates the `[@sentry/nextjs] DEPRECATION WARNING` that appeared on every build

## Testing
- `pnpm build` passes with no deprecation warnings from Sentry